### PR TITLE
Correct typo of 'space_tag' function's example & Add seperator parameter in 'space' function

### DIFF
--- a/soyspacing/countbase/_countbase.py
+++ b/soyspacing/countbase/_countbase.py
@@ -272,9 +272,9 @@ class CountSpace:
     
     def space_tag(self, doc, nonspace=0):
         '''
-            doc   = '이건 예시문장입니다'l
+            doc   = '이건 예시문장입니다'
             chars = '이건예시문장입니다'
-            tags  = list(0,1,000001)
+            tags  = list(0,1,0000001)
         '''
         chars = doc.replace(' ','')
         tags = [nonspace]*(len(chars) - 1) + [1]

--- a/soyspacing/countbase/_countbase.py
+++ b/soyspacing/countbase/_countbase.py
@@ -266,8 +266,8 @@ class CountSpace:
         return tags
     
     
-    def space(self, chars, tags):
-        return ''.join([c+' ' if t==1 else c for c,t in zip(chars, tags)]).strip()
+    def space(self, chars, tags, sep=' '):
+        return ''.join([c+sep if t==1 else c for c,t in zip(chars, tags)]).strip()
     
     
     def space_tag(self, doc, nonspace=0):
@@ -289,7 +289,7 @@ class CountSpace:
         return chars, tags
     
     
-    def correct(self, doc, verbose = False, min_count = 10, 
+    def correct(self, doc, sep=' ',verbose = False, min_count = 10, 
                 force_abs_threshold = 0.8, nonspace_threshold = -0.3, space_threshold = 0.3,
                 space_importancy = 1, rules = None, debug = False):
         '''
@@ -316,7 +316,7 @@ class CountSpace:
         
         if verbose:
             self.print_tags(tags, head = 'Input:')
-            print(self.space(chars, tags))
+            print(self.space(chars, tags, sep))
         
         # rule-based tagging
         if rules:
@@ -389,7 +389,7 @@ class CountSpace:
                 print('Unexpected bug. You are traped in infinite while loop. len(doc) = %d' % len(chars))
                 break
 
-        return self.space(chars, tags), tags
+        return self.space(chars, tags, sep), tags
 
     
     def force_tag(self, tags, length, features_list, scores_lcr, scores, force_abs_threshold, min_count, num_iter, verbose, is_updated, debug):


### PR DESCRIPTION
### Correct typo of "space_tag" function's example.
  - 예시 문장인 '이건 예시문장입니다' 는 chars길이가 9이므로
tags 리스트는 총 9개의 element를 갖습니다.
결과는 [0, 1, 0, 0, 0, 0, 0, 0, 1] 입니다.
 
- docstring에 명시된 tags = list(0, 1, 000001) 으로 0이 하나 빠졌으며, 
doc = '이건 예시문장입니다'l 에 l이 붙어있어 수정하면 좋을 듯 합니다.

### Add seperator parameter

  - 일반적으로 문장 띄어쓰기 교정을 위해 한칸 띄어쓰기로 교정된 string을 받지만,
경우에따라서,  구분자를 달리 하고 싶을 때,(ex. double space or \t ) 이를 제어할 수 있는 sep 파라미터 추가를 제안드립니다.